### PR TITLE
Adapt to pyansys org being renamed to ansys

### DIFF
--- a/.github/workflows/package_cleanup.yml
+++ b/.github/workflows/package_cleanup.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Delete untagged package versions"
-        uses: pyansys/actions/hk-package-clean-untagged@main
+        uses: ansys/actions/hk-package-clean-untagged@main
         with:
           package-org: 'ansys-internal'
           package-name: 'tools-filetransfer'


### PR DESCRIPTION
Fix reference to `pyansys/actions`, now located at `ansys/actions`.